### PR TITLE
CMake Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,64 @@
-cmake_minimum_required(VERSION 3.0)
-project(ascent)
+cmake_minimum_required(VERSION 3.12)
+project("ascent"
+		VERSION 0.5.0
+		DESCRIPTION "An extremely fast and flexible C++ simulation engine and differential equation solver."
+		HOMEPAGE_URL "https://github.com/AnyarInc/Ascent"
+		LANGUAGES CXX)
 
-if(MSVC)
-	# for ChaiScript
-	add_definitions(/bigobj)
-else()
-	set(DEBUG_FLAGS "-std=c++14")
-	set(RELEASE_FLAGS "-std=c++14")
-
-	set(CMAKE_CXX_FLAGS ${RELEASE_FLAGS})
-	set(CMAKE_CXX_FLAGS_DEBUG ${DEBUG_FLAGS})
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+include(CPack)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+	include(CTest)
 endif()
 
-## Put all binary files into /bin and libraries into /lib
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-set(ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-# ascent library
-add_library(ascent INTERFACE)
-target_include_directories(ascent INTERFACE
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-	$<INSTALL_INTERFACE:include>)
-	
-option(BUILD_EXAMPLES "Build example projects" TRUE)
-option(BUILD_UNIT_TESTS "Build unit testing project" TRUE)
-
-if(BUILD_EXAMPLES)
-   add_subdirectory(examples)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_14)
+if (MSVC)
+	target_compile_options(${PROJECT_NAME} INTERFACE "/bigobj") # for ChaiScript
 endif()
 
-if (BUILD_UNIT_TESTS)
+target_include_directories(
+  ${PROJECT_NAME}
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}_Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
+                                 VERSION ${PROJECT_VERSION}
+                                 COMPATIBILITY SameMajorVersion)
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION
+  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(EXPORT ${PROJECT_NAME}_Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+              "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR MODERN_CMAKE_BUILD_TESTING) AND BUILD_TESTING)
 	add_subdirectory(unit_tests)
+endif()
+
+option(BUILD_EXAMPLES "Build example projects" TRUE)
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_EXAMPLES)
+   add_subdirectory(examples)
 endif()

--- a/cmake/ascentConfig.cmake.in
+++ b/cmake/ascentConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(${PROJECT_NAME}_test src/main.cpp)
 target_link_libraries(${PROJECT_NAME}_test ascent)
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME}_test)

--- a/unit_tests/src/main.cpp
+++ b/unit_tests/src/main.cpp
@@ -30,13 +30,22 @@ bool test(const std::string& title, const double x, const double target, const d
       std::cout << title << " failed: " << to_string_precision(x, 12) << ", " << to_string_precision(target, 12) << '\n';
       return false;
    }
-   else
-   {
-      std::cout << title << " results: " << to_string_precision(x, 12) << ", " << to_string_precision(target, 12) << '\n';
-      return true;
-   }
+   std::cout << title << " results: " << to_string_precision(x, 12) << ", " << to_string_precision(target, 12) << '\n';
    return true;
 }
+
+struct TestResult {
+   TestResult& operator = (const bool &input) {
+      if (this->passed)
+         this->passed = input;
+      return *this;
+   }
+   bool failed() {
+      return !passed;
+   }
+private:
+   bool passed = true;
+};
 
 struct Airy
 {
@@ -172,44 +181,46 @@ std::pair<double, double> exponential_test_mod(const double dt)
 
 int main()
 {
+   TestResult res;
+
    auto x = airy_test<RK4>(0.001);
-   test("Airy RK4 x[0]", x[0], -0.200693641142, 1.0e-8);
-   test("Airy RK4 x[1]", x[1], -1.49817601143, 1.0e-8);
+   res = test("Airy RK4 x[0]", x[0], -0.200693641142, 1.0e-8);
+   res = test("Airy RK4 x[1]", x[1], -1.49817601143, 1.0e-8);
    x = airy_test<RK2>(0.001);
-   test("Airy RK2 x[0]", x[0], -0.200703911717, 1.0e-8);
-   test("Airy RK2 x[1]", x[1], -1.49816435475, 1.0e-8);
+   res = test("Airy RK2 x[0]", x[0], -0.200703911717, 1.0e-8);
+   res = test("Airy RK2 x[1]", x[1], -1.49816435475, 1.0e-8);
    x = airy_test<DOPRI45>(0.001);
-   test("Airy DOPRI45 x[0]", x[0], -0.200693641142, 1.0e-8); // compared to RK4 results
-   test("Airy DOPRI45 x[1]", x[1], -1.49817601143, 1.0e-8); // compared to RK4 results
+   res = test("Airy DOPRI45 x[0]", x[0], -0.200693641142, 1.0e-8); // compared to RK4 results
+   res = test("Airy DOPRI45 x[1]", x[1], -1.49817601143, 1.0e-8); // compared to RK4 results
    
    std::cout << "\n";
    auto x2 = airy_test_mod<modular::RK4<double>>(0.001);
-   test("Airy RK4 Modular a", x2[0], -0.200693641142, 1.0e-8);
-   test("Airy RK4 Modular b", x2[1], -1.49817601143, 1.0e-8);
+   res = test("Airy RK4 Modular a", x2[0], -0.200693641142, 1.0e-8);
+   res = test("Airy RK4 Modular b", x2[1], -1.49817601143, 1.0e-8);
    x2 = airy_test_mod<modular::RK2<double>>(0.001);
-   test("Airy RK2 Modular a", x2[0], -0.200703911717, 1.0e-8);
-   test("Airy RK2 Modular b", x2[1], -1.49816435475, 1.0e-8);
+   res = test("Airy RK2 Modular a", x2[0], -0.200703911717, 1.0e-8);
+   res = test("Airy RK2 Modular b", x2[1], -1.49816435475, 1.0e-8);
    x2 = airy_test_mod<modular::PC233<double>>(0.001);
-   test("Airy PC233 Modular a", x2[0], -0.200693641142, 1.0e-8);
-   test("Airy PC233 Modular b", x2[1], -1.49817601143, 1.0e-8);
+   res = test("Airy PC233 Modular a", x2[0], -0.200693641142, 1.0e-8);
+   res = test("Airy PC233 Modular b", x2[1], -1.49817601143, 1.0e-8);
 
    std::cout << "\n";
    auto result = exponential_test<RK4>(0.001);
-   test("Exponential RK4 x", result.first[0], exp(result.second), 1.0e-8);
+   res = test("Exponential RK4 x", result.first[0], exp(result.second), 1.0e-8);
    result = exponential_test<RK2>(0.001);
-   test("Exponential RK2 x", result.first[0], exp(result.second), 1.0e-1);
+   res = test("Exponential RK2 x", result.first[0], exp(result.second), 1.0e-1);
    result = exponential_test<DOPRI45>(0.001);
-   test("Exponential DOPRI45 x", result.first[0], exp(result.second), 1.0e-8);
+   res = test("Exponential DOPRI45 x", result.first[0], exp(result.second), 1.0e-8);
    result = exponential_test<PC233>(0.001);
-   test("Exponential PC233 x", result.first[0], exp(result.second), 1.0e-2);
+   res = test("Exponential PC233 x", result.first[0], exp(result.second), 1.0e-2);
 
    std::cout << "\n";
    auto result2 = exponential_test_mod<modular::RK4<double>>(0.001);
-   test("Exponential RK4 Modular x", result2.first, exp(result2.second), 1.0e-8);
+   res = test("Exponential RK4 Modular x", result2.first, exp(result2.second), 1.0e-8);
    result2 = exponential_test_mod<modular::RK2<double>>(0.001);
-   test("Exponential RK2 Modular x", result2.first, exp(result2.second), 1.0e-1);
+   res = test("Exponential RK2 Modular x", result2.first, exp(result2.second), 1.0e-1);
    result2 = exponential_test_mod<modular::PC233<double>>(0.001);
-   test("Exponential PC233 Modular x", result2.first, exp(result2.second), 1.0e-2);
+   res = test("Exponential PC233 Modular x", result2.first, exp(result2.second), 1.0e-2);
 
-   return 0;
+   return res.failed();
 }


### PR DESCRIPTION
If ascent is installed to the default path it should now be usable by other CMake projects using the  following:
```
cmake_minimum_required(VERSION 3.12)
project("example")

find_package(ascent REQUIRED)

add_executable(${PROJECT_NAME} src/main.cpp)
target_link_libraries(${PROJECT_NAME} ascent::ascent)
```
This should fix issue #3 