### PR TITLE
Use apply step in modular integrators and add Ralston integrator

### DIFF
--- a/include/ascent/integrators_modular/DOPRI45.h
+++ b/include/ascent/integrators_modular/DOPRI45.h
@@ -16,7 +16,7 @@
 
 #include "ascent/modular/Module.h"
 #include "ascent/integrators_modular/ModularIntegrators.h"
-
+#include "ascent/timing/Timing.h"
 #include "ascent/Utility.h"
 
 namespace asc
@@ -151,6 +151,7 @@ namespace asc
             if (!fsal_computed) // if an adaptive stepper hasn't computed the first same as last state, we must compute the step here
             {
                update(blocks);
+               apply(blocks);
 
                auto solve = [&](auto& state)
                {
@@ -189,6 +190,7 @@ namespace asc
             for (auto i = 0; i < 5; ++i)
             {
                update(blocks);
+               apply(blocks);
                propagate(blocks, propagator, dt);
                stepper(pass, t, dt);
                postprop(blocks);
@@ -196,6 +198,7 @@ namespace asc
             }
 
             update(blocks);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             postprop(blocks);
          }
@@ -214,6 +217,7 @@ namespace asc
 
             // xd6 is xd0, because first same as last (FSAL)
             update(blocks);
+            apply(blocks);
             for (auto& block : blocks)
             {
                auto solve = [&](auto& state)
@@ -292,7 +296,10 @@ namespace asc
             if (e_max > 1.0)
             {
                dt *= std::max(0.9_v * pow(e_max, -cx(1.0 / 3.0)), 0.2_v);
-               run_first->base_time_step(dt);
+
+               if (run_first) {
+                  run_first->base_time_step(dt);
+               }
 
                t = t0;
 
@@ -326,7 +333,10 @@ namespace asc
             {
                e_max = std::max(3.2e-4_v, e_max); // 3.2e-4 = pow(5, -5)
                dt *= 0.9_v * pow(e_max, -0.2_v);
-               run_first->base_time_step(dt);
+
+               if (run_first) {
+                  run_first->base_time_step(dt);
+               }
             }
 
             for (auto& block : blocks)

--- a/include/ascent/integrators_modular/Euler.h
+++ b/include/ascent/integrators_modular/Euler.h
@@ -44,6 +44,7 @@ namespace asc
          void operator()(modules_t& blocks, value_t& t, const value_t dt)
          {
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             t += dt;
             postprop(blocks);

--- a/include/ascent/integrators_modular/Heun.h
+++ b/include/ascent/integrators_modular/Heun.h
@@ -87,12 +87,14 @@ namespace asc
             pass = 0;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);

--- a/include/ascent/integrators_modular/NCRK4.h
+++ b/include/ascent/integrators_modular/NCRK4.h
@@ -102,23 +102,27 @@ namespace asc
             pass = 0;
             
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             postprop(blocks);
          }

--- a/include/ascent/integrators_modular/PC233.h
+++ b/include/ascent/integrators_modular/PC233.h
@@ -147,18 +147,21 @@ namespace asc
             pass = 0;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);

--- a/include/ascent/integrators_modular/RK2.h
+++ b/include/ascent/integrators_modular/RK2.h
@@ -91,12 +91,14 @@ namespace asc
             pass = 0;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);

--- a/include/ascent/integrators_modular/RK3.h
+++ b/include/ascent/integrators_modular/RK3.h
@@ -97,18 +97,21 @@ namespace asc
             pass = 0;
             
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);

--- a/include/ascent/integrators_modular/RK4.h
+++ b/include/ascent/integrators_modular/RK4.h
@@ -100,23 +100,27 @@ namespace asc
             pass = 0;
             
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
 
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             postprop(blocks);
          }

--- a/include/ascent/integrators_modular/RTAM3.h
+++ b/include/ascent/integrators_modular/RTAM3.h
@@ -96,12 +96,14 @@ namespace asc
             pass = 0;
             
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
             
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);

--- a/include/ascent/integrators_modular/RTAM4.h
+++ b/include/ascent/integrators_modular/RTAM4.h
@@ -98,12 +98,14 @@ namespace asc
             pass = 0;
             
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);
             ++pass;
             
             update(blocks, run_first);
+            apply(blocks);
             propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
             postprop(blocks);

--- a/include/ascent/integrators_modular/Ralston4.h
+++ b/include/ascent/integrators_modular/Ralston4.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Anyar, Inc.
+// Copyright (c) 2016-2020 Anyar, Inc.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,44 +17,51 @@
 #include "ascent/modular/Module.h"
 #include "ascent/integrators_modular/ModularIntegrators.h"
 
-// Second order, two pass Real Time (RT) Adams Moulton predictor-corrector integrator
-// A new family of real-time predictor-corrector integration algorithms
-// R.M. Howe. A new family of real-time predictor-corrector integration algorithms. The University of Michigan. September 1991.
+// Ralston's fourth-order method.
 
 namespace asc
 {
    namespace modular
    {
       template <class value_t>
-      struct RTAM2prop : public Propagator<value_t>
+      struct Ralston4prop : public Propagator<value_t>
       {
          void operator()(State& state, const value_t dt) override
          {
             auto& x = *state.x;
             auto& xd = *state.xd;
-            if (state.memory.size() < 2)
-            {
-               state.memory.resize(2);
-            }
+            state.memory.resize(5);
             auto& x0 = state.memory[0];
-            auto& xd1 = state.memory[1];
+            auto& xd0 = state.memory[1];
+            auto& xd1 = state.memory[2];
+            auto& xd2 = state.memory[3];
+            auto& xd3 = state.memory[4];
 
             switch (Propagator<value_t>::pass)
             {
             case 0:
                x0 = x;
-               x = x0 + dt / 8 * (5 * xd - xd1);
-               xd1 = xd;
+               xd0 = xd;  // k1
+               x = x0 + dt * (0.4 * xd0);
                break;
             case 1:
-               x = x0 + dt * xd; // where xd is the evaluated derivative at n + 1/2 (half a step)
+               xd1 = xd;  // k2
+               x = x0 + dt * (0.29697761 * xd0 + 0.15875964 * xd1);
+               break;
+            case 2:
+               xd2 = xd;  // k3
+               x = x0 + dt * (0.21810040 * xd0 - 3.05096516 * xd1 + 3.83286476 * xd2);
+               break;
+            case 3:
+               xd3 = xd; // k4
+               x = x0 + dt * (0.17476028 * xd0 - 0.55148066 * xd1 + 1.20553560 * xd2 + 0.17118478 * xd3);
                break;
             }
          }
       };
 
       template <class value_t>
-      struct RTAM2stepper : public TimeStepper<value_t>
+      struct Ralston4stepper : public TimeStepper<value_t>
       {
          value_t t0{};
 
@@ -64,9 +71,12 @@ namespace asc
             {
             case 0:
                t0 = t;
-               t += 0.5 * dt;
+               t = t0 + 0.4 * dt;
                break;
             case 1:
+               t = t0 + 0.45573725 * dt;
+               break;
+            case 2:
                t = t0 + dt;
                break;
             default:
@@ -76,14 +86,14 @@ namespace asc
       };
 
       template <class value_t>
-      struct RTAM2
+      struct Ralston4
       {
-         static constexpr size_t n_substeps = 2;
+         static constexpr size_t n_substeps = 4;
          
          asc::Module* run_first{};
-
-         RTAM2prop<value_t> propagator;
-         RTAM2stepper<value_t> stepper;
+		 
+         Ralston4prop<value_t> propagator;
+         Ralston4stepper<value_t> stepper;
 
          template <class modules_t>
          void operator()(modules_t& blocks, value_t& t, const value_t dt)
@@ -101,7 +111,19 @@ namespace asc
             update(blocks, run_first);
             apply(blocks);
             propagate(blocks, propagator, dt);
+            postprop(blocks);
+            ++pass;
+
+            update(blocks, run_first);
+            apply(blocks);
+            propagate(blocks, propagator, dt);
             stepper(pass, t, dt);
+            postprop(blocks);
+            ++pass;
+
+            update(blocks, run_first);
+            apply(blocks);
+            propagate(blocks, propagator, dt);
             postprop(blocks);
          }
       };


### PR DESCRIPTION
Utilizes already present apply() function in the modular integrators.
Adds Ralston's fourth-order method as a modular integrator.
