### PR TITLE
Make Timing::sample const and change asc::ChaiScript constructors

### DIFF
--- a/include/ascent/ChaiEngine.h
+++ b/include/ascent/ChaiEngine.h
@@ -111,10 +111,10 @@ namespace asc
          add(fun([] { return std::thread::hardware_concurrency(); }), "hardware_concurrency");
          add(fun([](asc::Recorder& rec, const int sig_digits) { rec.precision = sig_digits; }), "precision");
       }
-      ChaiEngine(const ChaiEngine&) = default;
-      ChaiEngine(ChaiEngine&&) = default;
-      ChaiEngine& operator=(const ChaiEngine&) = default;
-      ChaiEngine& operator=(ChaiEngine&&) = default;
+      ChaiEngine(const ChaiEngine&) = delete;
+      ChaiEngine(ChaiEngine&&) = delete;
+      ChaiEngine& operator=(const ChaiEngine&) = delete;
+      ChaiEngine& operator=(ChaiEngine&&) = delete;
 
    private:
       template <typename T>

--- a/include/ascent/timing/Timing.h
+++ b/include/ascent/timing/Timing.h
@@ -34,7 +34,7 @@ namespace asc
 
       SamplerT<value_t> sampler{ t, dt };
 
-      bool sample(const value_t sample_rate) noexcept
+      bool sample(const value_t sample_rate) const noexcept
       {
          return sampler(sample_rate);
       }


### PR DESCRIPTION
Timing::sample can be made `const` without consequence as it doesn't modify.

Ascent's version of ChaiScript declares copy/move constructors/assignments as default.
When I compiled Ascent's ChaiScript under clang, I received multiple warnings that these functions are implicitly deleted:
/ascent/include/ascent/ChaiEngine.h:117:19: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
      ChaiEngine& operator=(ChaiEngine&&) = default;
ascent/include/ascent/ChaiEngine.h:114:7: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
      ChaiEngine(const ChaiEngine&) = default;
and so on...