### PR TITLE
Include what Euler integrator uses

### DIFF
--- a/include/ascent/integrators_modular/Euler.h
+++ b/include/ascent/integrators_modular/Euler.h
@@ -16,6 +16,8 @@
 
 // Simple Euler integration.
 
+#include "ascent/modular/Module.h"
+#include "ascent/direct/State.h"
 #include "ascent/integrators_modular/ModularIntegrators.h"
 
 namespace asc


### PR DESCRIPTION
Doesn't compile on latest MSVC without it.