### PR TITLE
Additional Multistep Methods

### DIFF
--- a/include/ascent/Ascent.h
+++ b/include/ascent/Ascent.h
@@ -28,6 +28,7 @@
 #include "ascent/integrators/DOPRI45.h"
 #include "ascent/integrators/RTAM4.h"
 #include "ascent/integrators/PC233.h"
+#include "ascent/integrators/ABM4.h"
 
 // Linear Algebra
 #include "ascent/ParamV.h"
@@ -59,6 +60,7 @@ namespace asc
    using RK4 = RK4T<state_t>;
    using DOPRI45 = DOPRI45T<state_t>;
    using PC233 = PC233T<state_t>;
+   using ABM4 = ABM4T<state_t>;
 
    // Linear Algebra
    using ParamV = ParamVT<value_t>;

--- a/include/ascent/integrators/ABM4.h
+++ b/include/ascent/integrators/ABM4.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-2017 Anyar, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ascent/Utility.h"
+
+#include <array>
+
+namespace asc
+{
+   /// Fourth order Adams-Bashforth-Moulton Predictor Corrector. Fixed step version (Must reinitialize if dt is changed).
+   ///
+   /// \tparam state_t The state type of the system to be integrated. I.e. a std::vector or std::deque.
+   template <typename state_t, typename init_integrator = RK4T<state_t>>
+   struct ABM4T
+   {
+      using value_t = typename state_t::value_type;
+
+      /// \brief Integration step operation
+      /// 
+      /// Steps the system a single time step (dt), internally advances time (t)
+      ///
+      /// \tparam System The system object or function type. The system to be stepped must have a function syntax that takes \c (state_t, state_t, value_t) \c (x, xd, t).
+      /// The system can be a function, functor, or lambda expression. Taken as an rvalue reference.
+      /// \param[in, out] system The \c System instance.
+      /// \param[in, out] x The system's state vector.
+      /// \param[in, out] t The current time, which will be advanced by c\ dt.
+      /// \param[in] dt The time step for the input system to be advanced.
+      template <typename System>
+      void operator()(System &&system, state_t &x, value_t &t, const value_t dt)
+      {
+         if (initialized < 3)
+         {
+            const auto index = 2 - initialized;
+            xd_prev[index].resize(x.size());
+            system(x, xd_prev[index], t);
+            initializer(system, x, t, dt);
+            ++initialized;
+            return;
+         }
+
+         const size_t n = x.size();
+         if (xd0.size() < n)
+         {
+            xd0.resize(n);
+            xd_temp.resize(n);
+         }
+
+         x0 = x;
+         system(x, xd0, t);
+         size_t i{};
+         for (; i < n; ++i)
+            x[i] = x0[i] + c0 * dt * (55.0 * xd0[i] - 59.0 * xd_prev[0][i] + 37.0 * xd_prev[1][i] - 9.0 * xd_prev[2][i]);
+         t += dt;
+
+         system(x, xd_temp, t);
+         for (i = 0; i < n; ++i)
+            x[i] = x0[i] + c0 * dt * (9.0 * xd_temp[i] + 19.0 * xd0[i] - 5.0 * xd_prev[0][i] + xd_prev[1][i]);
+
+         for (i = 2; i > 0; --i)
+            xd_prev[i] = xd_prev[i - 1];
+         xd_prev[0] = xd0;
+      }
+
+   private:
+      int initialized{};
+      init_integrator initializer;
+      state_t x0, xd0, xd_temp;
+      std::array<state_t, 3> xd_prev; //previous time step derivative
+
+      static constexpr auto c0 = cx(1.0 / 24.0);
+   };
+}

--- a/include/ascent/integrators_modular/ABM4.h
+++ b/include/ascent/integrators_modular/ABM4.h
@@ -1,0 +1,226 @@
+// Copyright (c) 2016-2017 Anyar, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ascent/Utility.h"
+#include "ascent/integrators_modular/ModularIntegrators.h"
+#include "ascent/integrators_modular/RK4.h"
+
+// Fourth order Adams-Bashforth-Moulton Predictor Corrector. Fixed step version (Must reinitialize if dt is changed).
+namespace asc
+{
+   namespace modular
+   {
+      template <class value_t>
+      struct ABM4prop : public Propagator<value_t>
+      {
+         void operator()(State &state, const value_t dt) override
+         {
+            auto &x = *state.x;
+            auto &xd = *state.xd;
+            if (state.memory.size() < 6) {
+               state.memory.resize(6);
+            }
+            auto &x0 = state.memory[0];
+            auto &xd0 = state.memory[1];
+            auto &xp = state.memory[2]; // Can be used for error estimates
+            auto &xd_1 = state.memory[3];
+            auto &xd_2 = state.memory[4];
+            auto &xd_3 = state.memory[5];
+
+            switch (Propagator<value_t>::pass)
+            {
+            case 0:
+               x0 = x;
+               xd0 = xd;
+               x = x0 + c0 * dt * (55.0 * xd0 - 59.0 * xd_1 + 37.0 * xd_2 - 9.0 * xd_3);
+               xp = x;
+               break;
+            case 1:
+               x = x0 + c0 * dt * (9.0 * xd + 19.0 * xd0 - 5.0 * xd_1 + xd_2);
+               xd_3 = xd_2;
+               xd_2 = xd_1;
+               xd_1 = x0;
+               break;
+            }
+         }
+
+      private:
+         static constexpr auto c0 = cx(1.0 / 24.0);
+      };
+
+      template <class value_t>
+      struct ABM4stepper : public TimeStepper<value_t>
+      {
+         void operator()(const size_t pass, value_t &t, const value_t dt) override
+         {
+            switch (pass)
+            {
+            case 0:
+               t += dt;
+               break;
+            case 1:
+               break;
+            }
+         }
+      };
+
+      template <typename value_t, typename init_integrator = RK4<value_t>>
+      struct ABM4
+      {
+         asc::Module *run_first{};
+
+         ABM4prop<value_t> propagator;
+         ABM4stepper<value_t> stepper;
+
+         template <typename modules_t>
+         void operator()(modules_t &blocks, value_t &t, const value_t dt)
+         {
+            if (initialized < 3)
+            {
+               if (run_first)
+               {
+                  initializer.run_first = run_first;
+               }
+
+               // TODO: This is a bit is a bit weird and inefficient 
+               // state.xd may not be the derivitive at the current time after we run the initializer
+               // We need the derivitive at the current time so we call update once so we can grab xd before calling the initializer
+               update(blocks, run_first);
+               apply(blocks);
+
+               // Since running the initializer might overide the states we need to store them somewhere else until we have all the values
+               // TODO: This assumes the container is ordered
+               if (xd_temp.size() < blocks.size()) {
+                  xd_temp.resize(blocks.size());
+               }
+               if constexpr (is_pair_v<typename std::iterator_traits<typename modules_t::iterator>::value_type>)
+               {
+                  // Assign previous time step's derivative
+                  size_t i = 0;
+                  for (auto &block : blocks)
+                  {   
+                     auto &temp = xd_temp[i];
+                     if (temp.size() < block.second->states.size()) {
+                        temp.resize(block.second->states.size());
+                     }
+                     size_t j = 0;
+                     for (auto &state : block.second->states)
+                     {
+                        temp[j][2 - initialized] = *state.xd;
+                        ++j;
+                     }
+                     ++i;
+                  }
+               }
+               else
+               {
+                  // Assign previous time step's derivative
+                  size_t i = 0;
+                  for (auto &block : blocks)
+                  {   
+                     auto &temp = xd_temp[i];
+                     if (temp.size() < block->states.size()) {
+                        temp.resize(block->states.size());
+                     }
+                     size_t j = 0;
+                     for (auto &state : block->states)
+                     {
+                        temp[j][2 - initialized] = *state.xd;
+                        ++j;
+                     }
+                     ++i;
+                  }
+               }
+
+               // Run initializer integrator
+               initializer(blocks, t, dt);
+
+               ++initialized;
+
+               if (initialized == 3) {
+                  // Copy over stored history into state
+                  // TODO: This assumes the container is ordered
+                  if constexpr (is_pair_v<typename std::iterator_traits<typename modules_t::iterator>::value_type>)
+                  {
+                     // Assign previous time step's derivative
+                     size_t i = 0;
+                     for (auto &block : blocks)
+                     {
+                        auto &block_store = xd_temp[i];
+                        size_t j = 0;
+                        for (auto &state : block.second->states)
+                        {
+                           auto &state_store = block_store[j];
+                           if (state.memory.size() < 6) {
+                              state.memory.resize(6);
+                           }
+                           for (size_t k = 0; k < state_store.size(); ++k) {
+                              state.memory[k + 3] = state_store[k];
+                           }
+                           ++j;
+                        }
+                        ++i;
+                     }
+                  }
+                  else
+                  {
+                     // Assign previous time step's derivative
+                     size_t i = 0;
+                     for (auto &block : blocks)
+                     {
+                        auto &block_store = xd_temp[i];
+                        size_t j = 0;
+                        for (auto &state : block->states)
+                        {
+                           auto &state_store = block_store[j];
+                           if (state.memory.size() < 6) {
+                              state.memory.resize(6);
+                           }
+                           for (size_t k = 0; k < state_store.size(); ++k) {
+                              state.memory[k + 3] = state_store[k];
+                           }
+                           ++j;
+                        }
+                        ++i;
+                     }
+                  }
+               }
+               return;
+            }
+
+            auto &pass = propagator.pass;
+            pass = 0;
+
+            update(blocks, run_first);
+            apply(blocks);
+            propagate(blocks, propagator, dt);
+            stepper(pass, t, dt);
+            postprop(blocks);
+            ++pass;
+
+            update(blocks, run_first);
+            apply(blocks);
+            propagate(blocks, propagator, dt);
+            stepper(pass, t, dt);
+            postprop(blocks);
+         }
+
+         size_t initialized = 0;
+         init_integrator initializer;
+         std::vector<std::vector<std::array<value_t, 3>>> xd_temp; // Temp storage for initializer values;
+      };
+   }
+}

--- a/include/ascent/integrators_modular/VABM.h
+++ b/include/ascent/integrators_modular/VABM.h
@@ -19,6 +19,8 @@
 #include "ascent/integrators_modular/RK4.h"
 #include "ascent/timing/Timing.h"
 
+#include <cmath>
+
 // Variable step Adams-Bashforth-Moulton predictor corrector of configurable order.
 // This is based on Krogh's Variable Step Adams Formulas and the implementation in OrdinaryDiffEq.jl
 namespace asc
@@ -375,10 +377,10 @@ namespace asc
                   const auto phi_np1_a = &state.memory[propagator.phi_np1_i]; // Array length k+1
                   const auto phi_np1 = [&](size_t i) -> auto &{return *(phi_np1_a + i); };
 
-                  value_t lte = abs((propagator.g[order] - propagator.g[order - 1]) * phi_np1(order));
+                  value_t lte = std::abs((propagator.g[order] - propagator.g[order - 1]) * phi_np1(order));
 
-                  //value_t e = lte / (abs_tol + rel_tol * (abs(x0) + 0.01 * abs(xd0)));
-                  value_t e = std::max(lte / abs_tol, lte / (rel_tol * abs(x0)));
+                  //value_t e = lte / (abs_tol + rel_tol * (std::abs(x0) + 0.01 * std::abs(xd0)));
+                  value_t e = std::max(lte / abs_tol, lte / (rel_tol * std::abs(x0)));
 
                   if (e > e_max)
                   {
@@ -404,7 +406,7 @@ namespace asc
 
             if (e_max > 1.0)
             {
-               dt *= std::max(0.9_v * pow(e_max, -cx(1.0 / (order + 1))), 0.2_v);
+               dt *= std::max(0.9_v * std::pow(e_max, -cx(1.0 / (order + 1))), 0.2_v);
 
                if (run_first) {
                   run_first->base_time_step(dt);
@@ -446,7 +448,7 @@ namespace asc
             if (e_max < 0.5_v)
             {
                e_max = std::max(1e-7, e_max);
-               dt *= std::min(0.9_v * pow(e_max, -cx(1.0 / (order + 1))), 5.0_v);
+               dt *= std::min(0.9_v * std::pow(e_max, -cx(1.0 / (order + 1))), 5.0_v);
 
                if (run_first) {
                   run_first->base_time_step(dt);

--- a/include/ascent/integrators_modular/VABM.h
+++ b/include/ascent/integrators_modular/VABM.h
@@ -1,0 +1,468 @@
+// Copyright (c) 2016-2017 Anyar, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ascent/Utility.h"
+#include "ascent/integrators_modular/ModularIntegrators.h"
+#include "ascent/integrators_modular/RK4.h"
+#include "ascent/timing/Timing.h"
+
+// Variable step Adams-Bashforth-Moulton predictor corrector of configurable order.
+// This is based on Krogh's Variable Step Adams Formulas and the implementation in OrdinaryDiffEq.jl
+namespace asc
+{
+   namespace modular
+   {
+      template <class value_t>
+      struct VABMprop : public Propagator<value_t>
+      {
+         VABMprop(size_t order = 4)
+         {
+            set_order(order);
+         }
+
+         void calc_beta(size_t k) {
+            value_t xi = dt[0];
+            value_t xi_0 = 0.0;
+            beta[0] = 1.0;
+            for (size_t i = 1; i < k; ++i) {
+               xi_0 += dt[i];
+               beta[i] = beta[i - 1] * xi / xi_0;
+               xi += dt[i];
+            }
+         }
+
+         void calc_phi(State &state, value_t dx, size_t k) {
+            const auto phi_n_a = &state.memory[phi_n_i]; // Array length 4
+            const auto phi_star_n_a = &state.memory[phi_star_n_i]; // Array length 4
+            const auto phi_star_nm1_a = &state.memory[phi_star_nm1_i]; // Array length 4
+            const auto phi_n = [&](size_t i) -> auto &{return *(phi_n_a + i); };
+            const auto phi_star_n = [&](size_t i) -> auto &{return *(phi_star_n_a + i); };
+            const auto phi_star_nm1 = [&](size_t i) -> auto &{return *(phi_star_nm1_a + i); };
+
+            phi_n(0) = dx;
+            phi_star_n(0) = dx;
+            for (size_t i = 1; i < k; ++i) {
+               phi_n(i) = phi_n(i - 1) - phi_star_nm1(i - 1);
+               phi_star_n(i) = beta[i] * phi_n(i);
+            }
+         }
+
+         void calc_phi_np1(State &state, value_t dx, size_t k) {
+            const auto phi_star_n_a = &state.memory[phi_star_n_i]; // Array length 4
+            const auto phi_np1_a = &state.memory[phi_np1_i]; // Array length 4
+            const auto phi_star_n = [&](size_t i) -> auto &{return *(phi_star_n_a + i); };
+            const auto phi_np1 = [&](size_t i) -> auto &{return *(phi_np1_a + i); };
+
+            phi_np1(0) = dx;
+            for (size_t i = 1; i < k; ++i) {
+               phi_np1(i) = phi_np1(i - 1) - phi_star_n(i - 1);
+            }
+         }
+
+         void calc_g(size_t k) {
+            value_t xi = 0.0;
+            for (size_t i = 0; i < k; ++i) {
+               if (i > 0) {
+                  xi += dt[i - 1];
+               }
+               for (size_t j = 0; j < (k - i); ++j) {
+                  size_t q = j + 1;
+                  if (i == 0) {
+                     c[i][j] = 1.0 / q;
+                  }
+                  else if (i == 1) {
+                     c[i][j] = 1.0 / (q * (q + 1));
+                  }
+                  else {
+                     c[i][j] = (-dt[0] / xi) * c[i - 1][j + 1] + c[i - 1][j];
+                  }
+               }
+               g[i] = c[i][0] * dt[0];
+            }
+         }
+
+         void swap_phi_star(State &state) {
+            const auto phi_star_n_a = &state.memory[phi_star_n_i]; // Array length k
+            const auto phi_star_nm1_a = &state.memory[phi_star_nm1_i]; // Array length k
+            for (size_t i = 0; i < order; ++i) {
+               std::swap(*(phi_star_n_a + i), *(phi_star_nm1_a + i));
+            }
+         }
+
+         void operator()(State &state, const value_t dt) override
+         {
+            auto &x = *state.x;
+            auto &xd = *state.xd;
+            if (state.memory.size() < memory_size) {
+               state.memory.resize(memory_size);
+            }
+            auto &x0 = state.memory[x0_i];
+            auto &xd0 = state.memory[xd0_i];
+            auto &xp = state.memory[xp_i];
+            const auto phi_n_a = &state.memory[phi_n_i]; // Array length k
+            const auto phi_star_n_a = &state.memory[phi_star_n_i]; // Array length k
+            const auto phi_star_nm1_a = &state.memory[phi_star_nm1_i]; // Array length k
+            const auto phi_np1_a = &state.memory[phi_np1_i]; // Array length k+1
+            const auto phi_n = [&](size_t i) -> auto &{return *(phi_n_a + i); };
+            const auto phi_star_n = [&](size_t i) -> auto &{return *(phi_star_n_a + i); };
+            const auto phi_star_nm1 = [&](size_t i) -> auto &{return *(phi_star_nm1_a + i); };
+            const auto phi_np1 = [&](size_t i) -> auto &{return *(phi_np1_a + i); };
+
+            switch (Propagator<value_t>::pass)
+            {
+            case 0:
+               x0 = x;
+               calc_phi(state, xd, order);
+               for (size_t i = 0; i < order; ++i) {
+                  x += g[i] * phi_star_n(i);
+               }
+               xd0 = xd;
+               xp = x;
+               break;
+            case 1:
+               calc_phi_np1(state, xd, order + 1);
+               x += g[order] * phi_np1(order);
+               swap_phi_star(state);
+               break;
+            }
+         }
+
+         std::vector<value_t> dt;
+         std::vector<value_t> g;
+         static constexpr size_t x0_i = 0;
+         static constexpr size_t xd0_i = 1;
+         static constexpr size_t xp_i = 2;
+         static constexpr size_t phi_n_i = 3;
+         size_t phi_star_n_i{};
+         size_t phi_star_nm1_i{};
+         size_t phi_np1_i{};
+         size_t memory_size{};
+
+      private:
+
+         void set_order(size_t k) {
+            // This is private becuase we currently dont support dynamicly changing the order
+            order = k;
+            size_t k1 = order + 1;
+            dt.resize(order);
+            beta.resize(order);
+            g.resize(k1);
+            c.resize(k1);
+            for (size_t i = 0; i < k1; ++i) {
+               c[i].resize(k1);
+            }
+            phi_star_n_i = 3 + k;
+            phi_star_nm1_i = phi_star_n_i + k;
+            phi_np1_i = phi_star_nm1_i + k;
+            memory_size = phi_np1_i + k + 1;
+         }
+
+         size_t order{};
+         std::vector<value_t> beta;
+         std::vector<std::vector<value_t>> c; // Might want to flatten this.
+      };
+
+      template <class value_t>
+      struct VABMstepper : public TimeStepper<value_t>
+      {
+         void operator()(const size_t pass, value_t &t, const value_t dt) override
+         {
+            switch (pass)
+            {
+            case 0:
+               t += dt;
+               break;
+            case 1:
+               break;
+            }
+         }
+      };
+
+      /// Variable step Adams-Bashforth-Moulton predictor corrector of configurable order.
+      template <typename value_t, typename init_integrator = RK4<value_t>>
+      struct VABM : AdaptiveIntegrator
+      {
+         VABM(size_t order = 4) : order(order), propagator(order) {};
+
+         template <typename modules_t>
+         void operator()(modules_t &blocks, value_t &t, const value_t dt)
+         {
+            if (initialized < (order - 1))
+            {
+               if (run_first)
+               {
+                  initializer.run_first = run_first;
+               }
+
+               // TODO: This is a bit is a bit weird and inefficient 
+               // state.xd may not be the derivitive at the current time after we run the initializer
+               // We need the derivitive at the current time so we call update once so we can grab xd before calling the initializer
+               update(blocks, run_first);
+               apply(blocks);
+
+               // Since running the initializer might overide the states we need to store them somewhere else until we have all the values
+               // NOTE: This assumes the container is ordered
+               if (xd_temp.size() < blocks.size()) {
+                  xd_temp.resize(blocks.size());
+               }
+               if constexpr (is_pair_v<typename std::iterator_traits<typename modules_t::iterator>::value_type>)
+               {
+                  // Assign previous time step's derivative
+                  size_t i = 0;
+                  for (auto &block : blocks)
+                  {
+                     auto &temp = xd_temp[i];
+                     if (temp.size() < block.second->states.size()) {
+                        temp.resize(block.second->states.size());
+                     }
+                     size_t j = 0;
+                     for (auto &state : block.second->states)
+                     {
+                        temp[j].resize(order - 1);
+                        temp[j][initialized] = *state.xd;
+                        ++j;
+                     }
+                     ++i;
+                  }
+               }
+               else
+               {
+                  // Assign previous time step's derivative
+                  size_t i = 0;
+                  for (auto &block : blocks)
+                  {
+                     auto &temp = xd_temp[i];
+                     if (temp.size() < block->states.size()) {
+                        temp.resize(block->states.size());
+                     }
+                     size_t j = 0;
+                     for (auto &state : block->states)
+                     {
+                        temp[j].resize(order - 1);
+                        temp[j][initialized] = *state.xd;
+                        ++j;
+                     }
+                     ++i;
+                  }
+               }
+
+               // Run initializer integrator
+               initializer(blocks, t, dt);
+
+               propagator.dt[(order - 2) - initialized] = dt;
+
+               ++initialized;
+
+               if (initialized == (order - 1)) {
+                  propagator.calc_beta(order);
+
+                  // Copy over stored history into state
+                  // NOTE: This assumes the container is ordered
+                  if constexpr (is_pair_v<typename std::iterator_traits<typename modules_t::iterator>::value_type>)
+                  {
+                     // Assign previous time step's derivative
+                     size_t i = 0;
+                     for (auto &block : blocks)
+                     {
+                        auto &block_store = xd_temp[i];
+                        size_t j = 0;
+                        for (auto &state : block.second->states)
+                        {
+                           auto &state_store = block_store[j];
+                           if (state.memory.size() < propagator.memory_size) {
+                              state.memory.resize(propagator.memory_size);
+                           }
+                           for (size_t k = 0; k < state_store.size(); ++k) {
+                              propagator.calc_phi(state, state_store[k], k + 1);
+                              propagator.swap_phi_star(state);
+                           }
+                           ++j;
+                        }
+                        ++i;
+                     }
+                  }
+                  else
+                  {
+                     // Assign previous time step's derivative
+                     size_t i = 0;
+                     for (auto &block : blocks)
+                     {
+                        auto &block_store = xd_temp[i];
+                        size_t j = 0;
+                        for (auto &state : block->states)
+                        {
+                           auto &state_store = block_store[j];
+                           if (state.memory.size() < propagator.memory_size) {
+                              state.memory.resize(propagator.memory_size);
+                           }
+                           for (size_t k = 0; k < state_store.size(); ++k) {
+                              propagator.calc_phi(state, state_store[k], k + 1);
+                              propagator.swap_phi_star(state);
+                           }
+                           ++j;
+                        }
+                        ++i;
+                     }
+                  }
+               }
+               return;
+            }
+
+            for (size_t i = propagator.dt.size() - 1; i > 0; --i) {
+               propagator.dt[i] = propagator.dt[i - 1];
+            }
+            propagator.dt[0] = dt;
+
+            propagator.calc_g(order + 1);
+            propagator.calc_beta(order);
+
+            auto &pass = propagator.pass;
+            pass = 0;
+
+            update(blocks, run_first);
+            apply(blocks);
+            propagate(blocks, propagator, dt);
+            stepper(pass, t, dt);
+            postprop(blocks);
+            ++pass;
+
+            update(blocks, run_first);
+            apply(blocks);
+            propagate(blocks, propagator, dt);
+            stepper(pass, t, dt);
+            postprop(blocks);
+         }
+
+         template <class modules_t>
+         void operator()(modules_t &blocks, value_t &t, value_t &dt, const AdaptiveT<value_t> &settings)
+         {
+            const value_t abs_tol = settings.abs_tol;
+            const value_t rel_tol = settings.rel_tol;
+            const value_t safety_factor = settings.safety_factor;
+
+            const value_t t0 = t;
+
+         start_vabm_adaptive:
+
+            size_t init = initialized;
+            operator()(blocks, t, dt);
+            if (init < order - 1) {
+               return;
+            }
+
+            value_t e_max{};
+            for (auto &block : blocks)
+            {
+               auto solve = [&](auto &state)
+               {
+                  auto &x = *state.x;
+                  auto &xd = *state.xd;
+                  auto &x0 = state.memory[propagator.x0_i];
+                  auto &xd0 = state.memory[propagator.xd0_i];
+                  const auto phi_np1_a = &state.memory[propagator.phi_np1_i]; // Array length k+1
+                  const auto phi_np1 = [&](size_t i) -> auto &{return *(phi_np1_a + i); };
+
+                  value_t lte = abs((propagator.g[order] - propagator.g[order - 1]) * phi_np1(order));
+
+                  //value_t e = lte / (abs_tol + rel_tol * (abs(x0) + 0.01 * abs(xd0)));
+                  value_t e = std::max(lte / abs_tol, lte / (rel_tol * abs(x0)));
+
+                  if (e > e_max)
+                  {
+                     e_max = e;
+                  }
+               };
+
+               if constexpr (is_pair_v<typename std::iterator_traits<typename modules_t::iterator>::value_type>)
+               {
+                  for (auto &state : block.second->states)
+                  {
+                     solve(state);
+                  }
+               }
+               else
+               {
+                  for (auto &state : block->states)
+                  {
+                     solve(state);
+                  }
+               }
+            }
+
+            if (e_max > 1.0)
+            {
+               dt *= std::max(0.9_v * pow(e_max, -cx(1.0 / (order + 1))), 0.2_v);
+
+               if (run_first) {
+                  run_first->base_time_step(dt);
+               }
+
+               t = t0;
+
+               for (size_t i = 0; i < order - 1; ++i) {
+                  propagator.dt[i] = propagator.dt[i + 1];
+               }
+
+               for (auto &block : blocks)
+               {
+                  auto solve = [&](auto &state)
+                  {
+                     *state.x = state.memory[propagator.x0_i];
+                     propagator.swap_phi_star(state);
+                  };
+
+                  if constexpr (is_pair_v<typename std::iterator_traits<typename modules_t::iterator>::value_type>)
+                  {
+                     for (auto &state : block.second->states)
+                     {
+                        solve(state);
+                     }
+                  }
+                  else
+                  {
+                     for (auto &state : block->states)
+                     {
+                        solve(state);
+                     }
+                  }
+               }
+
+               goto start_vabm_adaptive; // recompute the solution recursively
+            }
+
+            if (e_max < 0.5_v)
+            {
+               e_max = std::max(1e-7, e_max);
+               dt *= std::min(0.9_v * pow(e_max, -cx(1.0 / (order + 1))), 5.0_v);
+
+               if (run_first) {
+                  run_first->base_time_step(dt);
+               }
+            }
+         }
+
+         asc::Timing<double> *run_first{};
+
+      private:
+         size_t order{};
+         size_t initialized = 0;
+         init_integrator initializer;
+         VABMprop<value_t> propagator;
+         VABMstepper<value_t> stepper;
+         std::vector<std::vector<std::vector<value_t>>> xd_temp; // Temp storage for initializer values;
+      };
+   }
+}


### PR DESCRIPTION
ABM4 is a fixed step Adams Bashforth Moulton method I added as both a standard integrator and a modular integrator. I have an adaptive version that reinitializes every time the timestep is changed but since you cant necessarily estimate the error on the initializer I decided that was a bad idea.

VABM uses the Krogh formulas for performing the Adams Bashforth Moulton method with varying timesteps so you don't have to reinitialize every time you change the timestep. This comes at the cost of calculating coefficients every timestep but if your system evaluations are expensive it may be worth it since you only need 2 system evaluations per step no matter your order. I'll update this to vary the order like ode113 if this is useful.