### PR TITLE
Sampler: allow different eps settings

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -3,35 +3,39 @@ name: clang
 on:
   push:
     branches:
-    - main
-    - feature/*
+      - main
+      - feature/*
     paths-ignore:
-    - '**.md'
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
     paths-ignore:
-    - '**.md'
+      - '**/*.md'
+      - 'docs/**'
+  workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Set Apple Clang 14 as the compiler
-      run: |
-        echo "CC=$(brew --prefix llvm@14)/bin/clang" >> "$GITHUB_ENV"
-        echo "CXX=$(brew --prefix llvm@14)/bin/clang++" >> "$GITHUB_ENV"
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
-      run: cmake --build build --config ${{env.BUILD_TYPE}} -j 2
+      run: cmake --build build --config ${{env.BUILD_TYPE}} -j 3
 
     - name: Test
       working-directory: build
-      run: ctest -C ${{env.BUILD_TYPE}} -j 2 --output-on-failure
+      run: ctest -C ${{env.BUILD_TYPE}} -j 3 --output-on-failure

--- a/include/ascent/timing/Sampler.h
+++ b/include/ascent/timing/Sampler.h
@@ -18,10 +18,13 @@
 
 namespace asc
 {
+   struct def_eps {
+      static constexpr double eps = 1e-8;
+   };
    // A Sampler resets the base time step when it goes out of scope. In this manner it can be used as a short-lived object within the simulation loop.
    // If the Sampler is to exist long term, then the reset() must be called after time is incremented within the simulation loop.
    // Note that keeping the Sampler around longer maintains a consistent base time step.
-   template <typename T>
+   template <typename T, class Eps = def_eps>
    struct SamplerT
    {
       SamplerT(T& _t, T& _dt) noexcept : t(_t), dt(_dt), dt_base(dt) {}
@@ -77,7 +80,7 @@ namespace asc
       }
 
    private:
-      static constexpr T eps = static_cast<T>(1.0e-8);
+      static constexpr T eps = static_cast<T>(Eps::eps);
       T& t;
       T& dt;
       T dt_base;


### PR DESCRIPTION
In a mixed simulation (digital + analog, like PWM control of the electric motor) default eps value is too big and simulation fails.